### PR TITLE
Fix overloaded call to abs()

### DIFF
--- a/src/vl53l0x_api_core.cpp
+++ b/src/vl53l0x_api_core.cpp
@@ -1906,7 +1906,7 @@ VL53L0X_Error VL53L0X_calc_sigma_estimate(VL53L0X_DEV Dev,
 		diff1_mcps <<= 8;
 
 		/* FixPoint0824/FixPoint1616 = FixPoint2408 */
-		xTalkCorrection	 = abs(diff1_mcps/diff2_mcps);
+		xTalkCorrection	 = (FixPoint1616_t)abs((long long)(diff1_mcps/diff2_mcps));
 
 		/* FixPoint2408 << 8 = FixPoint1616 */
 		xTalkCorrection <<= 8;


### PR DESCRIPTION
This is preventing compiling on deviceOS 2.0.0 on the Argon. This change fixes and allows compilation. See https://github.com/stm32duino/Arduino_Core_STM32/issues/660